### PR TITLE
POM.XML Not Correct

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
             </execution>
           </executions>
         </plugin>
+	</plugins>
 
   </build>
 


### PR DESCRIPTION
There is a missing terminator tag for "plugins" which is abrupting maven builds and integrity into other IDEs. This is the small fix.